### PR TITLE
feat(chat-input): add support for custom placeholder in ChatInput.Field

### DIFF
--- a/.changeset/gentle-falcons-rush.md
+++ b/.changeset/gentle-falcons-rush.md
@@ -1,5 +1,5 @@
 ---
-"@llamaindex/chat-ui": patch
+'@llamaindex/chat-ui': patch
 ---
 
 feat(chat-input): add support for custom placeholder in ChatInput.Field

--- a/.changeset/gentle-falcons-rush.md
+++ b/.changeset/gentle-falcons-rush.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/chat-ui": patch
+---
+
+feat(chat-input): add support for custom placeholder in ChatInput.Field

--- a/packages/chat-ui/src/chat/chat-input.tsx
+++ b/packages/chat-ui/src/chat/chat-input.tsx
@@ -22,6 +22,7 @@ interface ChatInputFormProps extends React.PropsWithChildren {
 interface ChatInputFieldProps {
   className?: string
   type?: 'input' | 'textarea'
+  placeholder?: string
 }
 
 interface ChatInputUploadProps {
@@ -125,7 +126,7 @@ function ChatInputField(props: ChatInputFieldProps) {
     return (
       <Input
         name="input"
-        placeholder="Type a message"
+        placeholder={props.placeholder ?? 'Type a message'}
         className={cn(props.className, 'min-h-0')}
         value={input}
         onChange={e => setInput(e.target.value)}
@@ -136,7 +137,7 @@ function ChatInputField(props: ChatInputFieldProps) {
   return (
     <Textarea
       name="input"
-      placeholder="Type a message"
+      placeholder={props.placeholder ?? 'Type a message'}
       className={cn(props.className, 'h-[40px] min-h-0 flex-1')}
       value={input}
       onChange={e => setInput(e.target.value)}


### PR DESCRIPTION
- Added `placeholder` prop to `ChatInputFieldProps` interface.
- Passed `placeholder` prop to Input and Textarea components.
- Default placeholder text remains "Type a message" if not provided.