### PR TITLE
Fix: correct LaTeX delimiter handling and escape dollar signs

### DIFF
--- a/apps/web/app/simple-demo.tsx
+++ b/apps/web/app/simple-demo.tsx
@@ -36,7 +36,7 @@ const initialMessages: Message[] = [
     id: '4',
     role: 'assistant',
     content:
-      "Let's explore a simple mathematical equation using LaTeX:\n\n The quadratic formula is: $$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$\n\nThis formula helps us solve quadratic equations in the form $ax^2 + bx + c = 0$. The solution gives us the x-values where the parabola intersects the x-axis.",
+    "Let's explore a simple mathematical equation using LaTeX:\n\n The quadratic formula is: \\[x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}\\]\n\nThis formula helps us solve quadratic equations in the form \\(ax^2 + bx + c = 0\\). The solution gives us the x-values where the parabola intersects the x-axis.",
   },
 ]
 

--- a/apps/web/app/simple-demo.tsx
+++ b/apps/web/app/simple-demo.tsx
@@ -36,7 +36,7 @@ const initialMessages: Message[] = [
     id: '4',
     role: 'assistant',
     content:
-    "Let's explore a simple mathematical equation using LaTeX:\n\n The quadratic formula is: \\[x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}\\]\n\nThis formula helps us solve quadratic equations in the form \\(ax^2 + bx + c = 0\\). The solution gives us the x-values where the parabola intersects the x-axis.",
+      "Let's explore a simple mathematical equation using LaTeX:\n\n The quadratic formula is: \\[x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}\\]\n\nThis formula helps us solve quadratic equations in the form \\(ax^2 + bx + c = 0\\). The solution gives us the x-values where the parabola intersects the x-axis.",
   },
 ]
 

--- a/packages/chat-ui/src/widgets/markdown.tsx
+++ b/packages/chat-ui/src/widgets/markdown.tsx
@@ -12,7 +12,6 @@ import {
 import { DocumentInfo } from './document-info'
 import { Citation, CitationComponentProps } from './citation'
 
-
 const MemoizedReactMarkdown: FC<Options> = memo(
   ReactMarkdown,
   (prevProps, nextProps) =>
@@ -24,20 +23,20 @@ const preprocessLaTeX = (content: string) => {
   // Escape dollar signs to prevent them from being treated as LaTeX math delimiters
   // For example, in "$10 million and $20 million", the content between the dollar signs might be incorrectly parsed as a math block
   // Replacing $ with \$ avoids this issue
-  const dollarSignProcessedContent = content.replace(/\$/g, '\\$');
-  
+  const dollarSignProcessedContent = content.replace(/\$/g, '\\$')
+
   // Replace block-level LaTeX delimiters \[ \] with $$ $$
   const blockProcessedContent = dollarSignProcessedContent.replace(
     /\\\[([\s\S]*?)\\\]/g,
     (_, equation) => `$$${equation}$$`
-  );
+  )
   // Replace inline LaTeX delimiters \( \) with $ $
   const inlineProcessedContent = blockProcessedContent.replace(
-      /\\\(([\s\S]*?)\\\)/g,
-      (_, equation) => `$${equation}$`
-  );
+    /\\\(([\s\S]*?)\\\)/g,
+    (_, equation) => `$${equation}$`
+  )
 
-  return inlineProcessedContent;
+  return inlineProcessedContent
 }
 
 const preprocessMedia = (content: string) => {

--- a/packages/chat-ui/src/widgets/markdown.tsx
+++ b/packages/chat-ui/src/widgets/markdown.tsx
@@ -12,6 +12,7 @@ import {
 import { DocumentInfo } from './document-info'
 import { Citation, CitationComponentProps } from './citation'
 
+
 const MemoizedReactMarkdown: FC<Options> = memo(
   ReactMarkdown,
   (prevProps, nextProps) =>
@@ -20,17 +21,23 @@ const MemoizedReactMarkdown: FC<Options> = memo(
 )
 
 const preprocessLaTeX = (content: string) => {
+  // Escape dollar signs to prevent them from being treated as LaTeX math delimiters
+  // For example, in "$10 million and $20 million", the content between the dollar signs might be incorrectly parsed as a math block
+  // Replacing $ with \$ avoids this issue
+  const dollarSignProcessedContent = content.replace(/\$/g, '\\$');
+  
   // Replace block-level LaTeX delimiters \[ \] with $$ $$
-  const blockProcessedContent = content.replace(
+  const blockProcessedContent = dollarSignProcessedContent.replace(
     /\\\[([\s\S]*?)\\\]/g,
     (_, equation) => `$$${equation}$$`
-  )
+  );
   // Replace inline LaTeX delimiters \( \) with $ $
   const inlineProcessedContent = blockProcessedContent.replace(
-    /\\\[([\s\S]*?)\\\]/g,
-    (_, equation) => `$${equation}$`
-  )
-  return inlineProcessedContent
+      /\\\(([\s\S]*?)\\\)/g,
+      (_, equation) => `$${equation}$`
+  );
+
+  return inlineProcessedContent;
 }
 
 const preprocessMedia = (content: string) => {


### PR DESCRIPTION
### 🛠️ Fix: Improve LaTeX Preprocessing Logic

#### Problem 1: Incorrect Regex for Inline Math

The existing logic incorrectly attempts to replace **inline** LaTeX delimiters using the wrong pattern:

```ts
// Old regex for inline math:
content.replace(/\\\[([\s\S]*?)\\\]/g, ...)
```

This matches `\[...\]`, which is **block-level** syntax, not inline.  
Inline math in LaTeX is denoted with `\\(...\\)`, so this pattern was failing to process inline math correctly.

---

#### Problem 2: Risky Use of `$` as a Math Delimiter

The current implementation converts LaTeX delimiters to `$...$` and `$$...$$`, which can conflict with regular content that includes dollar signs:

Example:
```text
"The product costs $10 and the discount is $5"
```

This could incorrectly treat `10 and the discount is` as a LaTeX expression.

---

### ✅ Solution

- Escapes all raw `$` signs in the content by replacing them with `\$`
- Correctly maps:
  - `\\[...\\]` ➜ `$$...$$` (block-level)
  - `\\(...\\)` ➜ `$...$` (inline)

Updated logic:
```ts
const preprocessLaTeX = (content: string) => {
  const dollarSignProcessedContent = content.replace(/\$/g, '\\$');

  const blockProcessedContent = dollarSignProcessedContent.replace(
    /\\\[([\s\S]*?)\\\]/g,
    (_, equation) => `$$${equation}$$`
  );

  const inlineProcessedContent = blockProcessedContent.replace(
    /\\\(([\s\S]*?)\\\)/g,
    (_, equation) => `$${equation}$`
  );

  return inlineProcessedContent;
}
```

---

### 🧪 Demo Update

Updated the demo content to use standard LaTeX delimiters (`\\[...\\]` and `\\(...\\)`), instead of embedding raw `$` signs:

#### Before:
```text
The quadratic formula is: $$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$
```

#### After:
```text
The quadratic formula is: \[x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}\]
```

This ensures the input content matches how most LLMs output LaTeX—using `\(...\)` for inline and `\[...\]` for block-level math.

---

### 📚 Why Avoid `$...$` for Math?

Why Avoid $...$ for Inline Math?
While $$...$$ works fine for block-level math, using $...$ for inline math is not recommended.

Dollar signs frequently appear in regular text—especially in financial or casual contexts—so $...$ can lead to incorrect parsing. For example, a sentence like:

"We raised $20 million and $10 million..."

might render incorrectly as:

"We raised 20*millionand*10 million..."

To avoid issues like this, it's better to use `\(...\)` for inline math and `\[...\]` for block math. This approach allows us to safely convert to dollar-based delimiters later, if needed, while avoiding ambiguity and parsing errors.

Ref: https://docs.mathjax.org/en/latest/input/tex/delimiters.html

---

## Improper regex for handling inline math \( \) 

E.g: `\( x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a} \)`

### Before
![Screenshot 2025-04-12 at 10 48 06 PM](https://github.com/user-attachments/assets/d86a0883-1156-4108-a11d-4fdcb1a42908)

### After

![Screenshot 2025-04-12 at 10 49 45 PM](https://github.com/user-attachments/assets/e6cd175e-f0de-4c41-9a6b-811b5de76f1d)

## Rendering issue when $ is used in non math content. 

E.g `$20 million and $10 million`

### Before
![Screenshot 2025-04-12 at 10 50 36 PM](https://github.com/user-attachments/assets/73e229ff-4837-4bea-8cb9-440984088ed4)

### After
![Screenshot 2025-04-12 at 10 51 13 PM](https://github.com/user-attachments/assets/2abd118b-8ad0-4b63-a633-652247129e9a)


### Verified math content renders properly with new changes
![Screenshot 2025-04-12 at 10 52 11 PM](https://github.com/user-attachments/assets/630c085d-4099-4f2b-adf3-b85ab6434ca6)