### PR TITLE
Expose ReactMarkdown `components` prop

### DIFF
--- a/.changeset/curly-buses-kick.md
+++ b/.changeset/curly-buses-kick.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/chat-ui": patch
+---
+
+Expose ReactMarkdown `components` prop

--- a/packages/chat-ui/src/chat/message-parts/parts/markdown.tsx
+++ b/packages/chat-ui/src/chat/message-parts/parts/markdown.tsx
@@ -1,20 +1,19 @@
-import { ComponentType } from 'react'
 import { cn } from '../../../lib/utils.js'
 import {
-  CitationComponentProps,
-  LanguageRendererProps,
   Markdown,
   preprocessSourceNodes,
+  type MarkdownProps,
 } from '../../../widgets/index.js'
 import { useChatMessage } from '../../chat-message.context.js'
-import { SourcesPartType, TextPartType } from '../types.js'
 import { usePart } from '../context.js'
+import { SourcesPartType, TextPartType } from '../types.js'
 import { getParts } from '../utils.js'
 
 interface ChatMarkdownProps extends React.PropsWithChildren {
-  citationComponent?: ComponentType<CitationComponentProps>
+  components?: MarkdownProps['components']
+  citationComponent?: MarkdownProps['citationComponent']
   className?: string
-  languageRenderers?: Record<string, ComponentType<LanguageRendererProps>>
+  languageRenderers?: MarkdownProps['languageRenderers']
 }
 
 /**
@@ -41,6 +40,7 @@ export function MarkdownPartUI(props: ChatMarkdownProps) {
     <Markdown
       content={markdown}
       sources={{ nodes }}
+      components={props.components}
       citationComponent={props.citationComponent}
       languageRenderers={props.languageRenderers}
       className={cn(


### PR DESCRIPTION
hey y'all, not sure whether you accept outside pull requests, but this one allows `components` to be passed through to `ReactMarkdown`. This came from a need to _tweak_ the hrefs in my project.

If it works for you, please let me know if any documentation or files should be updated to reflect the changes.

thanks for your consideration!
